### PR TITLE
Add Krungthep as fallback font

### DIFF
--- a/src/styles/scss/_base.scss
+++ b/src/styles/scss/_base.scss
@@ -62,7 +62,7 @@ body {
     -moz-osx-font-smoothing: grayscale;
     font-size: $md-size;
     color: $stupid-black;
-    font-family: "FA Sysfont C", monospace !important;
+    font-family: "FA Sysfont C", Krungthep, monospace !important;
     cursor: $cursor-auto-url, auto;
 }
 


### PR DESCRIPTION
Krungthep font comes with macOS and looks like FA Sysfont.

Before
![image](https://user-images.githubusercontent.com/193136/127764203-804df006-714e-494a-94cf-af6044bb2c53.png)

After
![image](https://user-images.githubusercontent.com/193136/127764200-9e3684fe-1050-4369-82d3-6deecc8efaa2.png)
